### PR TITLE
Improved multiselection widget readability by sorting its returned values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+- Improved multiselection widget readability by sorting its returned values 
+  [ichimdav]
+
 - Fixed overly long selection lists by displaying scrollbars for multiselection 
   widgets
   [ichimdav]

--- a/archetypes/querywidget/templates/multiple_selection_widget.pt
+++ b/archetypes/querywidget/templates/multiple_selection_widget.pt
@@ -10,6 +10,7 @@
                         index index|nothing;
                         widget_view nocall:context/@@archetypes-querywidget-multipleselectionwidget;
                         values potential_values|python:widget_view.getValues(index);
+                        sorted_values_keys python:widget_view.getSortedValuesKeys(values);
                         value value|nothing">
 
             <dl class="querywidget queryvalue multipleSelectionWidget">
@@ -18,7 +19,7 @@
                     <span class="multipleSelectionWidgetTitle" i18n:translate="">Select&hellip;</span>
                 </dt>
                 <dd>
-                    <tal:values repeat="index python:values.keys()">
+                    <tal:values repeat="index sorted_values_keys">
                         <label>
                             <input type="checkbox" name="query.v:records:list"
                                    tal:attributes="name python:str(fieldName)+'.v:records:list';

--- a/archetypes/querywidget/views.py
+++ b/archetypes/querywidget/views.py
@@ -71,3 +71,7 @@ class MultiSelectWidget(WidgetTraverse):
         if index is not None:
             values = config['indexes'][index]['values']
         return values
+
+    def getSortedValuesKeys(self, values):
+        # do a lowercase sort of the keys
+        return sorted(values.iterkeys(), key = lambda x : x.lower())


### PR DESCRIPTION
Without the values being sorted, when you are using this widget with plone.app.collection for the tags you get a list of unordered tags.

This is especially bad when you have a huge list of tags like any medium or large type of site could have, and having the values sorted helps you when trying to find a specific tag in an alphabetically ordered list.

With the css fixes from the previous merge and with the tags being sorted from this pull request, the tags management becomes more manageable.
