### PR TITLE
Also strip `/base_edit` or `/atct_edit` when fetching query results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Also strip `/base_edit` or `/atct_edit` when fetching query results
 
 
 1.1.3 (2016-08-12)

--- a/archetypes/querywidget/querywidget.js
+++ b/archetypes/querywidget/querywidget.js
@@ -157,7 +157,7 @@
 
     $.querywidget.updateSearch = function () {
         var base_url = $("base").attr("href");
-        base_url = base_url.replace(/\/edit$/, '');
+        base_url = base_url.replace(/\/[a-z_]*edit$/, '');
         if (base_url.indexOf("portal_factory") !== -1) {
             base_url = base_url.split("/").slice(0, -2).join("/");
         }


### PR DESCRIPTION
Otherwise the loaded results will be the edit view itself, which is
then injected and starts loading more results, which will be the edit
view again and so on and so on… a.k.a. edit view inception! :)