### PR TITLE
Catch 'click' events on widgets that were added after loading the DOM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New features:
 
 Bug fixes:
 
+- Catch click events on widgets that were added after loading the DOM
+
 - Also strip `/base_edit` or `/atct_edit` when fetching query results
 
 

--- a/archetypes/querywidget/querywidget.js
+++ b/archetypes/querywidget/querywidget.js
@@ -280,7 +280,7 @@
             });
         });
 
-        $('.multipleSelectionWidget dt').on('click', function () {
+        $(document).on('click', '.multipleSelectionWidget dt', function () {
             $(this).parent().children('dd').toggle();
         });
 


### PR DESCRIPTION
For (multi selection) widgets that were added after loading the DOM the 'click' event no longer worked because using `on` the selector needs to be on a wrapper element here (as well).

This fixes 019772d9 and belongs to #9.

Without this the widgets cannot be "opened" again when using jQuery 1.7, i.e. on Plone 4.x.